### PR TITLE
Fix null ref in WebsocketClient if disposed multiple times

### DIFF
--- a/Packages/StreamVideo/Runtime/Core/LowLevelClient/WebSockets/BasePersistentWebSocket.cs
+++ b/Packages/StreamVideo/Runtime/Core/LowLevelClient/WebSockets/BasePersistentWebSocket.cs
@@ -163,7 +163,7 @@ namespace StreamVideo.Core.LowLevelClient.WebSockets
             WebsocketClient.ConnectionFailed -= OnConnectionFailed;
             WebsocketClient.Disconnected -= OnDisconnected;
 
-            //StreamTodo: we're disposing the WS but we're not the owner, would be better to accept a factory method so we own the obj
+            //StreamTodo: we're disposing the WS but we're not the owner, would be better to receive a factory method so we own the obj
             WebsocketClient.Dispose();
         }
 
@@ -294,7 +294,7 @@ namespace StreamVideo.Core.LowLevelClient.WebSockets
         private void OnDisconnected()
         {
 #if STREAM_DEBUG_ENABLED
-            Logs.Warning($"{LogsPrefix} Websocket Disconnected");
+            Logs.Warning($"{LogsPrefix} Websocket Disconnected. Messages left: {WebsocketClient.QueuedMessagesCount}");
 #endif
             ConnectionState = ConnectionState.Disconnected;
         }

--- a/Packages/StreamVideo/Runtime/Core/LowLevelClient/WebSockets/SfuWebSocket.cs
+++ b/Packages/StreamVideo/Runtime/Core/LowLevelClient/WebSockets/SfuWebSocket.cs
@@ -138,7 +138,6 @@ namespace StreamVideo.Core.LowLevelClient.WebSockets
                 var sfuEvent = SfuEvent.Parser.ParseFrom(msg);
 
 #if STREAM_DEBUG_ENABLED
-
                 DebugLogEvent(sfuEvent);
 #endif
 

--- a/Packages/StreamVideo/Runtime/Libs/Websockets/IWebsocketClient.cs
+++ b/Packages/StreamVideo/Runtime/Libs/Websockets/IWebsocketClient.cs
@@ -12,6 +12,7 @@ namespace StreamVideo.Libs.Websockets
         event Action Connected;
         event Action Disconnected;
         event Action ConnectionFailed;
+        int QueuedMessagesCount { get; }
 
         bool TryDequeueMessage(out byte[] message);
 

--- a/Packages/StreamVideo/Runtime/Libs/Websockets/NativeWebSocketWrapper.cs
+++ b/Packages/StreamVideo/Runtime/Libs/Websockets/NativeWebSocketWrapper.cs
@@ -19,6 +19,8 @@ namespace StreamVideo.Libs.Websockets
         public event Action Connected;
         public event Action Disconnected;
         public event Action ConnectionFailed;
+        
+        public int QueuedMessagesCount => _messages.Count;
 
         public NativeWebSocketWrapper(ILogs logs, bool isDebugMode)
         {
@@ -82,6 +84,7 @@ namespace StreamVideo.Libs.Websockets
 
             UnsubscribeFromEvents();
             await _webSocket.Close();
+            _messages.Clear();
             Disconnected?.Invoke();
         }
 


### PR DESCRIPTION
(most probably a race condition) + clear message queues on disconnect