### PR TITLE
Add better support for disposable assets in tests.

### DIFF
--- a/Packages/StreamVideo/Tests/Editor/RepositoryTests.cs
+++ b/Packages/StreamVideo/Tests/Editor/RepositoryTests.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿#if STREAM_TESTS_ENABLED
+using System;
 using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using StreamVideo.Tests.Editor;
 using UnityEditor.PackageManager;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -94,3 +96,4 @@ namespace Tests.Editor
         }
     }
 }
+#endif

--- a/Packages/StreamVideo/Tests/Editor/SimpleFileCompare.cs
+++ b/Packages/StreamVideo/Tests/Editor/SimpleFileCompare.cs
@@ -1,4 +1,5 @@
-﻿namespace Tests.Editor
+﻿#if STREAM_TESTS_ENABLED
+namespace StreamVideo.Tests.Editor
 {
     /// <summary>
     /// This implementation defines a very simple comparison
@@ -25,3 +26,4 @@
         }
     }
 }
+#endif

--- a/Packages/StreamVideo/Tests/Runtime/CustomDataTests.cs
+++ b/Packages/StreamVideo/Tests/Runtime/CustomDataTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using StreamVideo.Tests.Shared;
 using UnityEngine.TestTools;
 
-namespace Tests.Runtime
+namespace StreamVideo.Tests.Runtime
 {
     internal class CustomDataTests : TestsBase
     {

--- a/Packages/StreamVideo/Tests/Shared/CoroutineRunner.cs
+++ b/Packages/StreamVideo/Tests/Shared/CoroutineRunner.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if STREAM_TESTS_ENABLED
+using UnityEngine;
 
 namespace StreamVideo.Tests.Shared
 {
@@ -13,3 +14,4 @@ namespace StreamVideo.Tests.Shared
         }
     }
 }
+#endif

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets.meta
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ddadeb192fbf416a9cbb5789d95bf859
+timeCreated: 1709292096

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetFactory.cs
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetFactory.cs
@@ -1,0 +1,25 @@
+﻿#if STREAM_TESTS_ENABLED
+using System.Collections.Generic;
+
+namespace StreamVideo.Tests.Shared.DisposableAssets
+{
+    public abstract class DisposableAssetFactory<TType>
+    {
+        public void DisposeInstances()
+        {
+            for (var i = _instances.Count - 1; i >= 0; i--)
+            {
+                OnDispose(_instances[i]);
+            }
+            
+            _instances.Clear();
+        }
+        
+        protected void TrackInstance(TType type) => _instances.Add(type);
+
+        protected abstract void OnDispose(TType instance);
+        
+        private readonly List<TType> _instances = new List<TType>();
+    }
+}
+#endif

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetFactory.cs.meta
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetFactory.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b2bf96ca02594b748ef850d6562135f4
+timeCreated: 1709292112

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetsProvider.cs
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetsProvider.cs
@@ -1,0 +1,14 @@
+﻿#if STREAM_TESTS_ENABLED
+namespace StreamVideo.Tests.Shared.DisposableAssets
+{
+    public class DisposableAssetsProvider
+    {
+        public WebCamTextureFactory WebCamTextureFactory { get; } = new WebCamTextureFactory();
+        
+        public void DisposeInstances()
+        {
+            WebCamTextureFactory.DisposeInstances();
+        }
+    }
+}
+#endif

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetsProvider.cs.meta
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets/DisposableAssetsProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6282fd91b2574356a81b3a746d742d02
+timeCreated: 1709292112

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets/WebCamTextureFactory.cs
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets/WebCamTextureFactory.cs
@@ -1,0 +1,24 @@
+﻿#if STREAM_TESTS_ENABLED
+using UnityEngine;
+
+namespace StreamVideo.Tests.Shared.DisposableAssets
+{
+    public class WebCamTextureFactory : DisposableAssetFactory<WebCamTexture>
+    {
+        public WebCamTexture Create(string deviceName, int width, int height, int fps)
+        {
+            var instance = new WebCamTexture(deviceName, width, height, fps);
+            TrackInstance(instance);
+            return instance;
+        }
+
+        protected override void OnDispose(WebCamTexture instance)
+        {
+            if (instance.isPlaying)
+            {
+                instance.Stop();
+            }
+        }
+    }
+}
+#endif

--- a/Packages/StreamVideo/Tests/Shared/DisposableAssets/WebCamTextureFactory.cs.meta
+++ b/Packages/StreamVideo/Tests/Shared/DisposableAssets/WebCamTextureFactory.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 88849c494f724ad795263cee25a51d5e
+timeCreated: 1709292112

--- a/Packages/StreamVideo/Tests/Shared/ITestClient.cs
+++ b/Packages/StreamVideo/Tests/Shared/ITestClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿#if STREAM_TESTS_ENABLED
+using System.Threading.Tasks;
 using StreamVideo.Core;
 using StreamVideo.Core.StatefulModels;
 
@@ -15,3 +16,4 @@ namespace StreamVideo.Tests.Shared
         Task ConnectAsync();
     }
 }
+#endif

--- a/Packages/StreamVideo/Tests/Shared/TestClient.cs
+++ b/Packages/StreamVideo/Tests/Shared/TestClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if STREAM_TESTS_ENABLED
+using System;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -124,3 +125,4 @@ namespace StreamVideo.Tests.Shared
         }
     }
 }
+#endif


### PR DESCRIPTION
Get them from a provider and they'll be auto-disposed on TearDown