### PR TITLE
Remove taking resolution and FPS from the RenderTexture component.

### DIFF
--- a/Packages/StreamVideo/Runtime/Core/LowLevelClient/RtcSession.cs
+++ b/Packages/StreamVideo/Runtime/Core/LowLevelClient/RtcSession.cs
@@ -125,9 +125,6 @@ namespace StreamVideo.Core.LowLevelClient
                 var prev = _videoInput;
                 _videoInput = value;
 
-                _publisherVideoSettings.MaxResolution = new VideoResolution((uint)value.width, (uint)value.height);
-                _publisherVideoSettings.FrameRate = (uint)value.requestedFPS;
-
                 if (prev != _videoInput)
                 {
                     VideoInputChanged?.Invoke(value);


### PR DESCRIPTION
This is controlled via passed or default publisher video setting + was causing issue on a Mac where camera took few frames to start and was returning invalid 16x16 resolution -> this resulted in generated video layers having invalid resolution