### PR TITLE
Disable compression due to fix Unity warning about app icons 

### DIFF
--- a/Assets/Samples/Stream Video & Audio Chat SDK/0.7.0/Video & Audio Chat Example Project/Images/AppIcon/stream_unity_logo.png.meta
+++ b/Assets/Samples/Stream Video & Audio Chat SDK/0.7.0/Video & Audio Chat Example Project/Images/AppIcon/stream_unity_logo.png.meta
@@ -70,7 +70,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 1
+    textureCompression: 0
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0


### PR DESCRIPTION
shouldn't have compression enabled. Fixes UNI-59