### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.ci.cd.workflow.yml
+++ b/.github/workflows/main.ci.cd.workflow.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: "0 5 * * *"  # run daily at 5 AM (UTC)
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_step1_create-release-pr.yml
+++ b/.github/workflows/release_step1_create-release-pr.yml
@@ -10,6 +10,9 @@ on:
         description: 'Changelog (for last version only & base64 encoded)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_step1_create-release-pr.yml
+++ b/.github/workflows/release_step1_create-release-pr.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build-and-release:

--- a/.github/workflows/release_step2_create-release-draft.yml
+++ b/.github/workflows/release_step2_create-release-draft.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   release-draft:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')

--- a/.github/workflows/release_step2_create-release-draft.yml
+++ b/.github/workflows/release_step2_create-release-draft.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
 
 jobs:
   release-draft:


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **3** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
