### PR TITLE
Fix race condition scenario -> lost video track if track arrives before TrackLookupPrefix  is updated

### DIFF
--- a/Packages/StreamVideo/Runtime/Core/LowLevelClient/RtcSession.cs
+++ b/Packages/StreamVideo/Runtime/Core/LowLevelClient/RtcSession.cs
@@ -1683,6 +1683,8 @@ namespace StreamVideo.Core.LowLevelClient
             UpdateParticipantTracksState(userId, sessionId, type, isEnabled: false, updateLocalParticipantState,
                 out var participant);
 
+            participant = EnsureParticipantFromSfuDto(participant, participantSfuDto);
+
             if (participant != null)
             {
                 participant.ClearTrackPausedByServer(type);
@@ -1718,6 +1720,8 @@ namespace StreamVideo.Core.LowLevelClient
 
             UpdateParticipantTracksState(userId, sessionId, type, isEnabled: true, updateLocalParticipantState: true,
                 out var participant);
+
+            participant = EnsureParticipantFromSfuDto(participant, participantSfuDto);
 
             if (participant != null)
             {
@@ -2470,6 +2474,19 @@ namespace StreamVideo.Core.LowLevelClient
 
         private static string GetTrackLookupPrefix(StreamVideoCallParticipant participant, Participant participantSfuDto)
             => participant?.TrackLookupPrefix ?? participantSfuDto?.TrackLookupPrefix;
+
+        // Large-call optimization: the SFU may skip ParticipantJoined and only embed the participant on the first
+        // TrackPublished/TrackUnpublished. Materialize the participant so buffered subscriber tracks can bind by prefix.
+        private StreamVideoCallParticipant EnsureParticipantFromSfuDto(StreamVideoCallParticipant participant,
+            Participant participantSfuDto)
+        {
+            if (participant != null || participantSfuDto == null || ActiveCall == null)
+            {
+                return participant;
+            }
+
+            return ActiveCall.AddOrUpdateParticipantFromSfu(participantSfuDto, _cache);
+        }
 
         private sealed class PendingTrack
         {

--- a/Packages/StreamVideo/Runtime/Core/LowLevelClient/RtcSession.cs
+++ b/Packages/StreamVideo/Runtime/Core/LowLevelClient/RtcSession.cs
@@ -604,6 +604,7 @@ namespace StreamVideo.Core.LowLevelClient
                     }
                     
                     ActiveCall.UpdateFromSfu(joinResponse);
+                    TryAssignAllPendingTracks();
                     _logs.WarningIfDebug($"{nameof(DoJoin)} - SFU Sending join response received. startNewPeerConnections: {startNewPeerConnections}");
 
                     _fastReconnectDeadlineSeconds = joinResponse.FastReconnectDeadlineSeconds;
@@ -1101,6 +1102,7 @@ namespace StreamVideo.Core.LowLevelClient
         private Tracer _subscriberTracer;
 
         private readonly List<SfuICETrickle> _pendingIceTrickleRequests = new List<SfuICETrickle>();
+        private readonly List<PendingTrack> _pendingTracks = new List<PendingTrack>();
         private readonly PublisherVideoSettings _publisherVideoSettings = PublisherVideoSettings.Default;
 
         private readonly Dictionary<string, VideoResolution> _videoResolutionByParticipantSessionId
@@ -1161,6 +1163,7 @@ namespace StreamVideo.Core.LowLevelClient
             }
 
             _pendingIceTrickleRequests.Clear();
+            _pendingTracks.Clear();
             _videoResolutionByParticipantSessionId.Clear();
             _incomingVideoRequestedByParticipantSessionId.Clear();
             _incomingAudioRequestedByParticipantSessionId.Clear();
@@ -1697,6 +1700,8 @@ namespace StreamVideo.Core.LowLevelClient
 
             QueueTracksSubscriptionRequest();
 
+            TryAssignPendingTracks(GetTrackLookupPrefix(participant, participantSfuDto));
+
             //StreamTodo: raise an event so user can react to track unpublished? Otherwise the video will just freeze
         }
 
@@ -1728,6 +1733,8 @@ namespace StreamVideo.Core.LowLevelClient
             }
 
             QueueTracksSubscriptionRequest();
+
+            TryAssignPendingTracks(GetTrackLookupPrefix(participant, participantSfuDto));
         }
 
         private void UpdateParticipantTracksState(string userId, string sessionId, TrackType trackType, bool isEnabled,
@@ -1957,6 +1964,8 @@ namespace StreamVideo.Core.LowLevelClient
             var id = $"{participantJoined.Participant.UserId}({participantJoined.Participant.SessionId})";
             _logs.Info($"Participant: {id} joined");
 
+            TryAssignPendingTracks(participantJoined.Participant?.TrackLookupPrefix);
+
             QueueTracksSubscriptionRequest();
         }
 
@@ -1968,6 +1977,8 @@ namespace StreamVideo.Core.LowLevelClient
             {
                 return;
             }
+
+            RemovePendingTracks(participantLeft.Participant?.TrackLookupPrefix);
 
             ActiveCall.UpdateFromSfu(participantLeft, _cache);
 
@@ -2033,6 +2044,7 @@ namespace StreamVideo.Core.LowLevelClient
         {
             _sfuTracer?.Trace("healthCheck", healthCheckResponse);
             ActiveCall.UpdateFromSfu(healthCheckResponse, _cache);
+            TryAssignAllPendingTracks();
         }
 
         private void OnSfuIceRestart(ICERestart iceRestart)
@@ -2149,7 +2161,8 @@ namespace StreamVideo.Core.LowLevelClient
                 return;
             }
 
-            _cache.TryCreateOrUpdate(participantUpdated.Participant);
+            var participant = _cache.TryCreateOrUpdate(participantUpdated.Participant);
+            TryAssignPendingTracks(participant?.TrackLookupPrefix);
         }
 
         private void OnSfuWebSocketOnCallEnded()
@@ -2266,35 +2279,66 @@ namespace StreamVideo.Core.LowLevelClient
 
         private void OnSubscriberStreamAdded(MediaStream mediaStream)
         {
-            var idParts = mediaStream.Id.Split(":");
-            var trackPrefix = idParts[0];
-            var trackTypeKey = idParts[1];
+            if (!TryParseSubscriberStreamId(mediaStream.Id, out var trackPrefix, out var trackTypeKey))
+            {
+                _logs.Error($"Malformed subscriber stream ID: {mediaStream.Id}");
+                return;
+            }
 
 #if STREAM_DEBUG_ENABLED
             _logs.Warning($"Subscriber stream received, trackPrefix: {trackPrefix}, trackTypeKey: {trackTypeKey}");
 #endif
 
-            var participant = ActiveCall.Participants.SingleOrDefault(p => p.TrackLookupPrefix == trackPrefix);
-            if (participant == null)
+            TryBindOrBufferSubscriberStream(trackPrefix, trackTypeKey, mediaStream);
+        }
+
+        private static bool TryParseSubscriberStreamId(string streamId, out string trackPrefix, out string trackTypeKey)
+        {
+            trackPrefix = null;
+            trackTypeKey = null;
+
+            var idParts = streamId.Split(':');
+            if (idParts.Length != 2 || string.IsNullOrEmpty(idParts[0]) || string.IsNullOrEmpty(idParts[1]))
             {
-                //StreamTodo: figure out severity of this case. Perhaps it's not an error, maybe we haven't received coordinator event yet like ParticipantJoined
-                _logs.Warning(
-                    $"Failed to find participant with trackPrefix: {trackPrefix} for media stream with ID: {mediaStream.Id}");
+                return false;
+            }
+
+            trackPrefix = idParts[0];
+            trackTypeKey = idParts[1];
+            return true;
+        }
+
+        private void TryBindOrBufferSubscriberStream(string trackPrefix, string trackTypeKey, MediaStream mediaStream)
+        {
+            var participant = FindParticipantByTrackPrefix(trackPrefix);
+            if (participant != null)
+            {
+                BindSubscriberStream(participant, trackTypeKey, mediaStream);
                 return;
             }
 
+            BufferPendingTrack(trackPrefix, trackTypeKey, mediaStream);
+        }
+
+        private StreamVideoCallParticipant FindParticipantByTrackPrefix(string trackPrefix)
+            => (StreamVideoCallParticipant)ActiveCall?.Participants
+                .SingleOrDefault(p => p.TrackLookupPrefix == trackPrefix);
+
+        protected virtual bool BindSubscriberStream(StreamVideoCallParticipant participant, string trackTypeKey,
+            MediaStream mediaStream)
+        {
             if (!TrackTypeExt.TryGetTrackType(trackTypeKey, out var trackType))
             {
                 _logs.Error(
                     $"Failed to get {typeof(TrackType)} for value: {trackTypeKey} on media stream with ID: {mediaStream.Id}");
-                return;
+                return false;
             }
 
             if (trackType == TrackType.Unspecified)
             {
                 _logs.Error(
                     $"Unexpected {nameof(trackType)} of value: {trackType} on media stream with ID: {mediaStream.Id}");
-                return;
+                return false;
             }
 
             //StreamTodo: assert that we expect exactly one track per type.
@@ -2306,13 +2350,141 @@ namespace StreamVideo.Core.LowLevelClient
                 track.Enabled = true;
             }
 
-            var internalParticipant = ((StreamVideoCallParticipant)participant);
-
             foreach (var track in mediaStream.GetTracks())
             {
-                internalParticipant.SetTrack(trackType, track, out var streamTrack);
-                ActiveCall.NotifyTrackAdded(internalParticipant, streamTrack);
+                participant.SetTrack(trackType, track, out var streamTrack);
+                ActiveCall.NotifyTrackAdded(participant, streamTrack);
             }
+
+            return true;
+        }
+
+        private void BufferPendingTrack(string trackPrefix, string trackTypeKey, MediaStream mediaStream)
+        {
+            if (ActiveCall == null)
+            {
+                _logs.Error(
+                    $"Received subscriber stream for unknown participant but {nameof(ActiveCall)} is null. Stream ID: {mediaStream.Id}");
+                return;
+            }
+
+            if (_pendingTracks.Any(entry => entry.StreamId == mediaStream.Id))
+            {
+                _logs.WarningIfDebug(
+                    $"Subscriber stream {mediaStream.Id} is already buffered for trackPrefix={trackPrefix}.");
+                return;
+            }
+
+            _pendingTracks.Add(new PendingTrack(
+                mediaStream.Id,
+                trackPrefix,
+                trackTypeKey,
+                mediaStream));
+
+            var awaitingPrefixSessionIds = ActiveCall.Participants
+                .Where(p => !p.IsLocalParticipant && string.IsNullOrEmpty(p.TrackLookupPrefix))
+                .Select(p => p.SessionId)
+                .ToList();
+
+            var awaitingPrefixDetails = awaitingPrefixSessionIds.Count == 0
+                ? "0 participant(s) awaiting TrackLookupPrefix"
+                : $"{awaitingPrefixSessionIds.Count} participant(s) awaiting TrackLookupPrefix: [{string.Join(", ", awaitingPrefixSessionIds)}]";
+
+            _logs.Warning(
+                $"Received track for unknown participant. Buffered subscriber stream {mediaStream.Id}: no participant for trackPrefix={trackPrefix}. {awaitingPrefixDetails}");
+        }
+
+        private void TryAssignPendingTracks(string trackLookupPrefix)
+        {
+            if (ActiveCall == null || string.IsNullOrEmpty(trackLookupPrefix) || _pendingTracks.Count == 0)
+            {
+                return;
+            }
+
+            var participant = FindParticipantByTrackPrefix(trackLookupPrefix);
+            if (participant == null)
+            {
+                return;
+            }
+
+            var pendingEntries = _pendingTracks
+                .Where(entry => entry.TrackPrefix == trackLookupPrefix)
+                .ToList();
+
+            if (pendingEntries.Count == 0)
+            {
+                return;
+            }
+
+            var assignedCount = 0;
+            foreach (var entry in pendingEntries)
+            {
+                try
+                {
+                    if (BindSubscriberStream(participant, entry.TrackTypeKey, entry.MediaStream))
+                    {
+                        _pendingTracks.Remove(entry);
+                        assignedCount++;
+                    }
+                    else
+                    {
+                        _pendingTracks.Remove(entry);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logs.Exception(e);
+                    _pendingTracks.Remove(entry);
+                }
+            }
+
+            if (assignedCount > 0)
+            {
+                _logs.Info(
+                    $"Assigned {assignedCount} pending track(s) for trackPrefix={trackLookupPrefix}, sessionId={participant.SessionId}");
+            }
+        }
+
+        private void TryAssignAllPendingTracks()
+        {
+            if (_pendingTracks.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var trackPrefix in _pendingTracks.Select(entry => entry.TrackPrefix).Distinct().ToList())
+            {
+                TryAssignPendingTracks(trackPrefix);
+            }
+        }
+
+        private void RemovePendingTracks(string trackLookupPrefix)
+        {
+            if (string.IsNullOrEmpty(trackLookupPrefix) || _pendingTracks.Count == 0)
+            {
+                return;
+            }
+
+            _pendingTracks.RemoveAll(entry => entry.TrackPrefix == trackLookupPrefix);
+        }
+
+        private static string GetTrackLookupPrefix(StreamVideoCallParticipant participant, Participant participantSfuDto)
+            => participant?.TrackLookupPrefix ?? participantSfuDto?.TrackLookupPrefix;
+
+        private sealed class PendingTrack
+        {
+            public PendingTrack(string streamId, string trackPrefix, string trackTypeKey, MediaStream mediaStream)
+            {
+                StreamId = streamId;
+                TrackPrefix = trackPrefix;
+                TrackTypeKey = trackTypeKey;
+                MediaStream = mediaStream;
+            }
+
+            public string StreamId { get; }
+            public string TrackPrefix { get; }
+            public string TrackTypeKey { get; }
+            public MediaStream MediaStream { get; }
         }
 
         private void CreateSubscriber(IEnumerable<ICEServer> iceServers)

--- a/Packages/StreamVideo/Runtime/Core/Models/CallSession.cs
+++ b/Packages/StreamVideo/Runtime/Core/Models/CallSession.cs
@@ -8,6 +8,7 @@ using StreamVideo.Core.State.Caches;
 using StreamVideo.Core.StatefulModels;
 using StreamVideo.Core.Utils;
 using SfuCallState = StreamVideo.v1.Sfu.Models.CallState;
+using SfuParticipant = StreamVideo.v1.Sfu.Models.Participant;
 using SfuParticipantCount = StreamVideo.v1.Sfu.Models.ParticipantCount;
 
 namespace StreamVideo.Core.Models
@@ -172,6 +173,24 @@ namespace StreamVideo.Core.Models
                 _participants.Add(participant);
                 ParticipantAdded?.Invoke(participant);
             }
+        }
+
+        /// <summary>
+        /// Creates or updates a participant from an SFU participant DTO and ensures it's part of the session.
+        /// Used for the large-call optimization where the SFU skips <c>ParticipantJoined</c> and only embeds the
+        /// participant on the first <c>TrackPublished</c>/<c>TrackUnpublished</c> event.
+        /// </summary>
+        internal StreamVideoCallParticipant AddOrUpdateParticipantFromSfu(SfuParticipant participantDto, ICache cache)
+        {
+            var participant = cache.TryCreateOrUpdate(participantDto);
+
+            if (!_participants.Contains(participant))
+            {
+                _participants.Add(participant);
+                ParticipantAdded?.Invoke(participant);
+            }
+
+            return participant;
         }
 
         internal void UpdateFromSfu(HealthCheckResponse healthCheckResponse, ICache cache)

--- a/Packages/StreamVideo/Runtime/Core/StatefulModels/StreamCall.cs
+++ b/Packages/StreamVideo/Runtime/Core/StatefulModels/StreamCall.cs
@@ -724,6 +724,9 @@ namespace StreamVideo.Core.StatefulModels
             Session.UpdateFromSfu(participantJoined, cache);
         }
 
+        internal StreamVideoCallParticipant AddOrUpdateParticipantFromSfu(Participant participantDto, ICache cache)
+            => Session.AddOrUpdateParticipantFromSfu(participantDto, cache);
+
         internal void UpdateFromSfu(ParticipantLeft participantLeft, ICache cache)
         {
             try

--- a/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs
+++ b/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs
@@ -232,13 +232,24 @@ namespace StreamVideo.Tests.Editor
 
         private static MediaStream CreateMediaStream(string streamId)
         {
-            var ptr = WebRTC.Context.CreateMediaStream(streamId);
+            var context = GetWebRtcContext();
+            var ptr = (IntPtr)context.GetType()
+                .GetMethod("CreateMediaStream", BindingFlags.Instance | BindingFlags.Public)
+                .Invoke(context, new object[] { streamId });
             return (MediaStream)Activator.CreateInstance(
                 typeof(MediaStream),
                 BindingFlags.Instance | BindingFlags.NonPublic,
                 binder: null,
                 args: new object[] { ptr },
                 culture: null);
+        }
+
+        private static object GetWebRtcContext()
+        {
+            var contextProperty = typeof(WebRTC).GetProperty("Context",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            Assert.That(contextProperty, Is.Not.Null, "Expected internal WebRTC.Context property.");
+            return contextProperty.GetValue(null);
         }
 
         private static StreamVideoCallParticipant GetRemoteParticipant(StreamCall call)

--- a/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs
+++ b/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs
@@ -1,0 +1,352 @@
+#if STREAM_TESTS_ENABLED
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using StreamVideo.Core;
+using StreamVideo.Core.Configs;
+using StreamVideo.Core.LowLevelClient;
+using StreamVideo.Core.LowLevelClient.WebSockets;
+using StreamVideo.Core.Models;
+using StreamVideo.Core.State;
+using StreamVideo.Core.State.Caches;
+using StreamVideo.Core.StatefulModels;
+using StreamVideo.Libs.Logs;
+using StreamVideo.Libs.NetworkMonitors;
+using StreamVideo.Libs.Serialization;
+using StreamVideo.Libs.Time;
+using StreamVideo.Tests.Shared;
+using StreamVideo.v1.Sfu.Events;
+using StreamVideo.v1.Sfu.Models;
+using Unity.WebRTC;
+using UnityEngine.TestTools;
+using Participant = StreamVideo.v1.Sfu.Models.Participant;
+using SfuTrackType = StreamVideo.v1.Sfu.Models.TrackType;
+
+namespace StreamVideo.Tests.Editor
+{
+    /// <summary>
+    /// Tests for pending remote track buffering in <see cref="RtcSession"/>.
+    /// </summary>
+    internal sealed class PendingRemoteTrackBufferTests
+    {
+        private const string CallCid = "test:call";
+        private const string RemoteSessionId = "remote-session";
+        private const string RemoteUserId = "remote-user";
+        private const string TrackPrefix = "abc123";
+        private const string VideoTrackTypeKey = "TRACK_TYPE_VIDEO";
+
+        [SetUp]
+        public void SetUp()
+        {
+            _currentTime = 0f;
+            _timeService = Substitute.For<ITimeService>();
+            _timeService.Time.Returns(_ => _currentTime);
+
+            var factory = Substitute.For<ISfuWebSocketFactory>();
+            factory.Create().Returns(Substitute.For<ISfuWebSocket>());
+
+            _session = new PendingRemoteTrackBufferTestRtcSession(
+                sfuWebSocketFactory: factory,
+                httpClientFactory: _ => null,
+                logs: Substitute.For<ILogs>(),
+                serializer: Substitute.For<ISerializer>(),
+                timeService: _timeService,
+                lowLevelClient: null,
+                config: StreamClientConfig.Default,
+                networkMonitor: Substitute.For<INetworkMonitor>());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _session?.Dispose();
+        }
+
+        [UnityTest]
+        public IEnumerator When_stream_arrives_before_prefix_set_expect_buffered()
+            => When_stream_arrives_before_prefix_set_expect_buffered_Async().RunAsIEnumerator();
+
+        private Task When_stream_arrives_before_prefix_set_expect_buffered_Async()
+        {
+            SetupCallWithRemoteParticipant(trackLookupPrefix: string.Empty);
+            InvokeSubscriberStreamAdded(CreateMediaStream($"{TrackPrefix}:{VideoTrackTypeKey}"));
+
+            Assert.That(_session.BindAttempts, Is.Empty,
+                "Stream should be buffered when TrackLookupPrefix is not yet known.");
+            Assert.That(GetPendingTrackCount(), Is.EqualTo(1),
+                "Expected one pending subscriber stream in the buffer.");
+            return Task.CompletedTask;
+        }
+
+        [UnityTest]
+        public IEnumerator When_participant_joined_expect_pending_stream_bound()
+            => When_participant_joined_expect_pending_stream_bound_Async().RunAsIEnumerator();
+
+        private Task When_participant_joined_expect_pending_stream_bound_Async()
+        {
+            var remoteParticipant = SetupCallWithRemoteParticipant(trackLookupPrefix: string.Empty);
+            ConfigureParticipantCache(remoteParticipant);
+
+            InvokeSubscriberStreamAdded(CreateMediaStream($"{TrackPrefix}:{VideoTrackTypeKey}"));
+            Assert.That(GetPendingTrackCount(), Is.EqualTo(1),
+                "Precondition: stream should be buffered before ParticipantJoined.");
+
+            InvokeParticipantJoined(new ParticipantJoined
+            {
+                CallCid = CallCid,
+                Participant = new Participant
+                {
+                    SessionId = RemoteSessionId,
+                    UserId = RemoteUserId,
+                    TrackLookupPrefix = TrackPrefix,
+                },
+            });
+
+            Assert.That(_session.BindAttempts, Has.Count.EqualTo(1),
+                "Pending stream should bind after ParticipantJoined sets TrackLookupPrefix.");
+            Assert.That(_session.BindAttempts[0].TrackPrefix, Is.EqualTo(TrackPrefix),
+                "Bound stream should use the participant track prefix.");
+            Assert.That(GetPendingTrackCount(), Is.EqualTo(0),
+                "Buffer should be empty after a successful drain.");
+            Assert.That(remoteParticipant.TrackLookupPrefix, Is.EqualTo(TrackPrefix),
+                "ParticipantJoined should hydrate TrackLookupPrefix.");
+            return Task.CompletedTask;
+        }
+
+        [UnityTest]
+        public IEnumerator When_track_published_with_participant_dto_expect_pending_stream_bound()
+            => When_track_published_with_participant_dto_expect_pending_stream_bound_Async().RunAsIEnumerator();
+
+        private Task When_track_published_with_participant_dto_expect_pending_stream_bound_Async()
+        {
+            var remoteParticipant = SetupCallWithRemoteParticipant(trackLookupPrefix: string.Empty);
+            InvokeSubscriberStreamAdded(CreateMediaStream($"{TrackPrefix}:{VideoTrackTypeKey}"));
+            Assert.That(GetPendingTrackCount(), Is.EqualTo(1),
+                "Precondition: stream should be buffered before TrackPublished.");
+
+            InvokeTrackPublished(new TrackPublished
+            {
+                UserId = RemoteUserId,
+                SessionId = RemoteSessionId,
+                Type = SfuTrackType.Video,
+                Participant = new Participant
+                {
+                    SessionId = RemoteSessionId,
+                    UserId = RemoteUserId,
+                    TrackLookupPrefix = TrackPrefix,
+                },
+            });
+
+            Assert.That(_session.BindAttempts, Has.Count.EqualTo(1),
+                "Pending stream should bind after TrackPublished embeds participant prefix.");
+            Assert.That(GetPendingTrackCount(), Is.EqualTo(0),
+                "Buffer should be empty after TrackPublished drain.");
+            Assert.That(remoteParticipant.TrackLookupPrefix, Is.EqualTo(TrackPrefix),
+                "TrackPublished participant DTO should hydrate TrackLookupPrefix.");
+            return Task.CompletedTask;
+        }
+
+        [UnityTest]
+        public IEnumerator When_participant_already_has_prefix_expect_immediate_bind()
+            => When_participant_already_has_prefix_expect_immediate_bind_Async().RunAsIEnumerator();
+
+        private Task When_participant_already_has_prefix_expect_immediate_bind_Async()
+        {
+            SetupCallWithRemoteParticipant(trackLookupPrefix: TrackPrefix);
+            InvokeSubscriberStreamAdded(CreateMediaStream($"{TrackPrefix}:{VideoTrackTypeKey}"));
+
+            Assert.That(_session.BindAttempts, Has.Count.EqualTo(1),
+                "Stream should bind immediately when TrackLookupPrefix is already known.");
+            Assert.That(GetPendingTrackCount(), Is.EqualTo(0),
+                "Buffer should remain empty on immediate bind.");
+            return Task.CompletedTask;
+        }
+
+        private StreamVideoCallParticipant SetupCallWithRemoteParticipant(string trackLookupPrefix)
+        {
+            var call = CreateCallWithRemoteParticipant(_session, RemoteSessionId, trackLookupPrefix);
+            _session.ActiveCall = call;
+            return GetRemoteParticipant(call);
+        }
+
+        private void ConfigureParticipantCache(StreamVideoCallParticipant remoteParticipant)
+        {
+            var cache = Substitute.For<ICache>();
+            var participantsRepo = Substitute.For<ICacheRepository<StreamVideoCallParticipant>>();
+            cache.CallParticipants.Returns(participantsRepo);
+            participantsRepo
+                .CreateOrUpdate<StreamVideoCallParticipant, Participant>(Arg.Any<Participant>(), out _)
+                .Returns(callInfo =>
+                {
+                    var dto = callInfo.Arg<Participant>();
+                    remoteParticipant.UpdateFromSfu(dto);
+                    callInfo[1] = false;
+                    return remoteParticipant;
+                });
+
+            _session.SetCache(cache);
+        }
+
+        private void InvokeSubscriberStreamAdded(MediaStream mediaStream)
+            => InvokeSfuHandler("OnSubscriberStreamAdded", mediaStream);
+
+        private void InvokeParticipantJoined(ParticipantJoined participantJoined)
+            => InvokeSfuHandler("OnSfuParticipantJoined", participantJoined);
+
+        private void InvokeTrackPublished(TrackPublished trackPublished)
+            => InvokeSfuHandler("OnSfuTrackPublished", trackPublished);
+
+        private void InvokeSfuHandler(string methodName, object eventArg)
+        {
+            var method = typeof(RtcSession).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null, $"Expected private handler `{methodName}` on {nameof(RtcSession)}.");
+            method.Invoke(_session, new[] { eventArg });
+        }
+
+        private int GetPendingTrackCount()
+        {
+            var field = typeof(RtcSession).GetField("_pendingTracks",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, "Expected pending track buffer field on RtcSession.");
+            return ((IReadOnlyCollection<object>)field.GetValue(_session)).Count;
+        }
+
+        private static MediaStream CreateMediaStream(string streamId)
+        {
+            var ptr = WebRTC.Context.CreateMediaStream(streamId);
+            return (MediaStream)Activator.CreateInstance(
+                typeof(MediaStream),
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { ptr },
+                culture: null);
+        }
+
+        private static StreamVideoCallParticipant GetRemoteParticipant(StreamCall call)
+        {
+            var callSession = (CallSession)typeof(StreamCall)
+                .GetField("_session", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(call);
+            var participants = (List<StreamVideoCallParticipant>)typeof(CallSession)
+                .GetField("_participants", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(callSession);
+            return participants.Single();
+        }
+
+        private static StreamCall CreateCallWithRemoteParticipant(RtcSession session, string remoteSessionId,
+            string trackLookupPrefix)
+        {
+            var call = new StreamCall(CallCid,
+                Substitute.For<ICacheRepository<StreamCall>>(),
+                Substitute.For<IStatefulModelContext>());
+
+            var participantContext = CreateParticipantContext(session);
+            var participant = new StreamVideoCallParticipant(
+                remoteSessionId,
+                Substitute.For<ICacheRepository<StreamVideoCallParticipant>>(),
+                participantContext);
+
+            ((IUpdateableFrom<Participant, StreamVideoCallParticipant>)participant).UpdateFromDto(
+                new Participant
+                {
+                    SessionId = remoteSessionId,
+                    UserId = RemoteUserId,
+                    TrackLookupPrefix = trackLookupPrefix ?? string.Empty,
+                },
+                participantContext.Cache);
+
+            var callSession = new CallSession();
+            var participants = (List<StreamVideoCallParticipant>)typeof(CallSession)
+                .GetField("_participants", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(callSession);
+            participants.Add(participant);
+
+            typeof(StreamCall)
+                .GetField("_session", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(call, callSession);
+
+            return call;
+        }
+
+        private static IStatefulModelContext CreateParticipantContext(RtcSession session)
+        {
+            var context = Substitute.For<IStatefulModelContext>();
+            context.Cache.Returns(Substitute.For<ICache>());
+            context.Logs.Returns(Substitute.For<ILogs>());
+            context.Serializer.Returns(Substitute.For<ISerializer>());
+
+            var client = Substitute.For<IInternalStreamVideoClient>();
+            client.InternalLowLevelClient.Returns(CreateLowLevelClientShim(session));
+            context.Client.Returns(client);
+
+            return context;
+        }
+
+        private static StreamVideoLowLevelClient CreateLowLevelClientShim(RtcSession session)
+        {
+            var lowLevelClient = (StreamVideoLowLevelClient)RuntimeHelpers.GetUninitializedObject(
+                typeof(StreamVideoLowLevelClient));
+
+            foreach (var field in typeof(StreamVideoLowLevelClient).GetFields(
+                         BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                if (field.FieldType == typeof(RtcSession))
+                {
+                    field.SetValue(lowLevelClient, session);
+                }
+            }
+
+            return lowLevelClient;
+        }
+
+        private float _currentTime;
+        private ITimeService _timeService;
+        private PendingRemoteTrackBufferTestRtcSession _session;
+
+        private readonly struct CapturedBindAttempt
+        {
+            public CapturedBindAttempt(string trackPrefix, string trackTypeKey, string sessionId)
+            {
+                TrackPrefix = trackPrefix;
+                TrackTypeKey = trackTypeKey;
+                SessionId = sessionId;
+            }
+
+            public string TrackPrefix { get; }
+            public string TrackTypeKey { get; }
+            public string SessionId { get; }
+        }
+
+        private sealed class PendingRemoteTrackBufferTestRtcSession : RtcSession
+        {
+            public List<CapturedBindAttempt> BindAttempts { get; } = new List<CapturedBindAttempt>();
+
+            public PendingRemoteTrackBufferTestRtcSession(ISfuWebSocketFactory sfuWebSocketFactory,
+                Func<IStreamCall, HttpClient> httpClientFactory,
+                ILogs logs, ISerializer serializer, ITimeService timeService,
+                StreamVideoLowLevelClient lowLevelClient,
+                IStreamClientConfig config, INetworkMonitor networkMonitor)
+                : base(sfuWebSocketFactory, httpClientFactory, logs, serializer,
+                    timeService, lowLevelClient, config, networkMonitor)
+            {
+            }
+
+            protected override bool BindSubscriberStream(StreamVideoCallParticipant participant, string trackTypeKey,
+                MediaStream mediaStream)
+            {
+                BindAttempts.Add(new CapturedBindAttempt(participant.TrackLookupPrefix, trackTypeKey,
+                    participant.SessionId));
+                return true;
+            }
+        }
+    }
+}
+#endif

--- a/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs
+++ b/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs
@@ -127,10 +127,19 @@ namespace StreamVideo.Tests.Editor
 
         private Task When_track_published_with_participant_dto_expect_pending_stream_bound_Async()
         {
-            var remoteParticipant = SetupCallWithRemoteParticipant(trackLookupPrefix: string.Empty);
+            // Large-call optimization: the SFU skips ParticipantJoined and only embeds the participant on the first
+            // TrackPublished. The participant is therefore absent from the call when the subscriber stream arrives.
+            var call = CreateEmptyCall();
+            _session.ActiveCall = call;
+
+            var remoteParticipant = CreateRemoteParticipant(RemoteSessionId, trackLookupPrefix: string.Empty);
+            ConfigureParticipantCache(remoteParticipant);
+
             InvokeSubscriberStreamAdded(CreateMediaStream($"{TrackPrefix}:{VideoTrackTypeKey}"));
             Assert.That(GetPendingTrackCount(), Is.EqualTo(1),
                 "Precondition: stream should be buffered before TrackPublished.");
+            Assert.That(call.Participants, Is.Empty,
+                "Precondition: no participant should exist before TrackPublished in the large-call path.");
 
             InvokeTrackPublished(new TrackPublished
             {
@@ -145,6 +154,8 @@ namespace StreamVideo.Tests.Editor
                 },
             });
 
+            Assert.That(call.Participants, Has.Count.EqualTo(1),
+                "TrackPublished with embedded DTO should materialize the participant (large-call path).");
             Assert.That(_session.BindAttempts, Has.Count.EqualTo(1),
                 "Pending stream should bind after TrackPublished embeds participant prefix.");
             Assert.That(GetPendingTrackCount(), Is.EqualTo(0),
@@ -172,7 +183,7 @@ namespace StreamVideo.Tests.Editor
 
         private StreamVideoCallParticipant SetupCallWithRemoteParticipant(string trackLookupPrefix)
         {
-            var call = CreateCallWithRemoteParticipant(_session, RemoteSessionId, trackLookupPrefix);
+            var call = CreateCallWithRemoteParticipant(RemoteSessionId, trackLookupPrefix);
             _session.ActiveCall = call;
             return GetRemoteParticipant(call);
         }
@@ -241,14 +252,22 @@ namespace StreamVideo.Tests.Editor
             return participants.Single();
         }
 
-        private static StreamCall CreateCallWithRemoteParticipant(RtcSession session, string remoteSessionId,
-            string trackLookupPrefix)
+        private StreamCall CreateEmptyCall()
         {
             var call = new StreamCall(CallCid,
                 Substitute.For<ICacheRepository<StreamCall>>(),
                 Substitute.For<IStatefulModelContext>());
 
-            var participantContext = CreateParticipantContext(session);
+            typeof(StreamCall)
+                .GetField("_session", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(call, new CallSession());
+
+            return call;
+        }
+
+        private StreamVideoCallParticipant CreateRemoteParticipant(string remoteSessionId, string trackLookupPrefix)
+        {
+            var participantContext = CreateParticipantContext(_session);
             var participant = new StreamVideoCallParticipant(
                 remoteSessionId,
                 Substitute.For<ICacheRepository<StreamVideoCallParticipant>>(),
@@ -263,16 +282,24 @@ namespace StreamVideo.Tests.Editor
                 },
                 participantContext.Cache);
 
-            var callSession = new CallSession();
+            return participant;
+        }
+
+        private static void AddParticipantToCall(StreamCall call, StreamVideoCallParticipant participant)
+        {
+            var callSession = (CallSession)typeof(StreamCall)
+                .GetField("_session", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(call);
             var participants = (List<StreamVideoCallParticipant>)typeof(CallSession)
                 .GetField("_participants", BindingFlags.Instance | BindingFlags.NonPublic)
                 .GetValue(callSession);
             participants.Add(participant);
+        }
 
-            typeof(StreamCall)
-                .GetField("_session", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(call, callSession);
-
+        private StreamCall CreateCallWithRemoteParticipant(string remoteSessionId, string trackLookupPrefix)
+        {
+            var call = CreateEmptyCall();
+            AddParticipantToCall(call, CreateRemoteParticipant(remoteSessionId, trackLookupPrefix));
             return call;
         }
 

--- a/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs.meta
+++ b/Packages/StreamVideo/Tests/Editor/PendingRemoteTrackBufferTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4e8f1a23b7d4e5096a8213f5d0c9b72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/StreamVideo/Tests/Editor/StreamVideo.Tests.asmdef
+++ b/Packages/StreamVideo/Tests/Editor/StreamVideo.Tests.asmdef
@@ -5,6 +5,7 @@
         "StreamVideo.Core",
         "StreamVideo.Libs",
         "StreamVideo.Tests.Shared",
+        "Stream.Unity.WebRTC",
         "TNRD.NSubstitute"
     ],
     "includePlatforms": [


### PR DESCRIPTION
if SFU track is received before TrackLookupPrefix is populated -> the track is lost. We now collect unassigned tracks that couldn't be matched and try matching them whenever updating the lookup prefix, in case track arrived earlier